### PR TITLE
Update Makefile: Add error handling, fallback for bpftool, and reorder installation steps 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,37 @@
 .PHONY: all update upgrade install_llvm install_clang install_bpftool install_go install_bpftrace set_path source_profile
 
-install: update upgrade install_llvm install_clang install_bpftool install_go install_bpftrace set_path source_profile 
+install: update upgrade install_llvm install_clang install_go install_bpftrace install_bpftool set_path source_profile
+
+.ONESHELL:
+SHELL := /bin/bash
 
 update:
-	sudo apt update -y
+	sudo apt update -y || { echo "Update failed"; exit 1; }
 
 upgrade:
-	sudo apt upgrade -y
+	sudo apt upgrade -y || { echo "Upgrade failed"; exit 1; }
 
 install_llvm:
-	sudo apt install -y llvm
+	sudo apt install -y llvm || { echo "LLVM installation failed"; exit 1; }
 
 install_clang:
-	sudo apt install -y clang
-
-install_bpftool:
-	sudo apt install -y bpftool
+	sudo apt install -y clang || { echo "Clang installation failed"; exit 1; }
 
 install_bpftrace:
-	sudo apt install -y bpftrace
+	sudo apt install -y bpftrace || { echo "bpftrace installation failed"; exit 1; }
 
 install_go:
-	wget https://golang.org/dl/go1.20.2.linux-amd64.tar.gz
-	sudo tar -C /usr/local -xzf go1.20.2.linux-amd64.tar.gz
+	wget https://golang.org/dl/go1.20.2.linux-amd64.tar.gz || { echo "Go download failed"; exit 1; }
+	sudo tar -C /usr/local -xzf go1.20.2.linux-amd64.tar.gz || { echo "Go extraction failed"; exit 1; }
+
+install_bpftool:
+	sudo apt install -y bpftool || { echo "bpftool installation failed, falling back to linux-tools-common"; sudo apt install -y linux-tools-common; }
 
 set_path:
-	echo "export PATH=/usr/local/go/bin:${PATH}" | sudo tee -a $HOME/.profile
+	echo "export PATH=/usr/local/go/bin:${PATH}" | sudo tee -a $HOME/.profile || { echo "Setting PATH failed"; exit 1; }
+
+source_profile:
+	source $HOME/.profile || { echo "Sourcing profile failed"; exit 1; }
 
 gen_vmlinux:
-	sudo bpftool btf dump file /sys/kernel/btf/vmlinux format c > ./bpf/headers/vmlinux.h
+	sudo /usr/local/go/bin/bpftool btf dump file /sys/kernel/btf/vmlinux format c > ./bpf/headers/vmlinux.h || { echo "Generating vmlinux.h failed"; exit 1; }

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ install_bpftool:
 	sudo apt install -y bpftool || { echo "bpftool installation failed, falling back to linux-tools-common"; sudo apt install -y linux-tools-common; }
 
 set_path:
-	echo "export PATH=/usr/local/go/bin:${PATH}" | sudo tee -a $HOME/.profile || { echo "Setting PATH failed"; exit 1; }
+	echo "export PATH=/usr/local/go/bin/go:${PATH}" | sudo tee -a $HOME/.profile || { echo "Setting PATH failed"; exit 1; }
 
 source_profile:
 	source $HOME/.profile || { echo "Sourcing profile failed"; exit 1; }

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,6 @@
 
 install: update upgrade install_llvm install_clang install_go install_bpftrace install_bpftool set_path source_profile
 
-.ONESHELL:
-SHELL := /bin/bash
-
 update:
 	sudo apt update -y || { echo "Update failed"; exit 1; }
 
@@ -33,5 +30,6 @@ set_path:
 source_profile:
 	source $HOME/.profile || { echo "Sourcing profile failed"; exit 1; }
 
+
 gen_vmlinux:
-	sudo /usr/local/go/bin/bpftool btf dump file /sys/kernel/btf/vmlinux format c > ./bpf/headers/vmlinux.h || { echo "Generating vmlinux.h failed"; exit 1; }
+	sudo bpftool btf dump file /sys/kernel/btf/vmlinux format c > ./bpf/headers/vmlinux.h


### PR DESCRIPTION
## Summary
 This pull request updates the `Makefile` ensure the installation process is not interrupted by errors .
### The changes include:
   - Added error handling for each installation step.
   - Introduced a fallback mechanism for `bpftool` installation: if `bpftool` fails, the script will attempt to install `linux-tools-common`.
   - Reordered the installation steps to ensure that the failure of `bpftool` does not affect the installation of other components.
   - fix: updated go binary path 
   
   
![ssebpf](https://github.com/xmigrate/ebee/assets/83550433/00311969-59ab-48e9-942e-28456b8772d3)
